### PR TITLE
fixed a few issues reported by golint and added the ability to do strict/non-strict filtering of IPs in order to accomodate proxied requests

### DIFF
--- a/ipfilter_test.go
+++ b/ipfilter_test.go
@@ -431,3 +431,32 @@ func TestIPs(t *testing.T) {
 		}
 	}
 }
+
+func TestGetClientIP(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("Could not create HTTP request: %v", err)
+	}
+
+	// Setting up the test data
+	remoteAddr := "8.8.4.4:12345"
+	remoteIP, _, _ := net.SplitHostPort(remoteAddr)
+	fwdFor := "8.8.8.8"
+	req.RemoteAddr = remoteAddr
+
+	// Testing 'getClientIP' should return 'fwdFor' when 'X-Forwarded-For' is defined
+	req.Header.Set("X-Forwarded-For", fwdFor)
+
+	clientIP, _ := getClientIP(req)
+	if clientIP.String() != fwdFor {
+		t.Fatalf("Expected clientIP: '%s', Got: '%s'", fwdFor, clientIP.String())
+	}
+
+	// Testing 'getClientIP' should return 'remoteIP' when 'X-Forwarded-For' is not defined
+	req.Header.Del("X-Forwarded-For")
+
+	clientIP, _ = getClientIP(req)
+	if clientIP.String() != remoteIP {
+		t.Fatalf("Expected clientIP: '%s', Got: '%s'", remoteIP, clientIP.String())
+	}
+}


### PR DESCRIPTION
Here is a quick fix for to support filtering of IPs as reported in the issue #3 . 

Please note that, by default, the middleware will now behave the same was as the logs in caddy which means that the "strict" option will be turned 'off'. (i.e.: 'X-Forwarded-For' client ip will override the req.RemoteAddr if, and only if, said header is non-empty) This might be considered a "breaking change" so let me know if this is problematic for you.

Also, I added a few tests but they are not full-blown http test as you already have other tests covering this. Since these existing tests did not break, I only added a bunch of assertions covering the new function I added to extract the proper client ip.